### PR TITLE
shuffle by natural numbers instead of real numbers

### DIFF
--- a/bindings/python/lib.cpp
+++ b/bindings/python/lib.cpp
@@ -160,6 +160,7 @@ BOOST_PYTHON_MODULE(libcloudphxx)
       .def_readwrite("sd_conc_mean", &lgr::opts_init_t<real_t>::sd_conc_mean)
       .def_readwrite("chem_rho", &lgr::opts_init_t<real_t>::chem_rho)
       .def_readwrite("RH_max", &lgr::opts_init_t<real_t>::RH_max)
+      .def_readwrite("rng_seed", &lgr::opts_init_t<real_t>::rng_seed)
       .add_property("kernel_parameters", &lgrngn::get_kp<real_t>, &lgrngn::set_kp<real_t>)
     ;
     bp::class_<lgr::particles_proto_t<real_t>/*, boost::noncopyable*/>("particles_proto_t")

--- a/include/libcloudph++/lgrngn/arrinfo.hpp
+++ b/include/libcloudph++/lgrngn/arrinfo.hpp
@@ -12,11 +12,11 @@ namespace libcloudphxx
     struct arrinfo_t
     {
       // member fields:
+      const std::vector<ptrdiff_t> strvec; // see alt. ctor below
       real_t * const dataZero;
       const ptrdiff_t *strides;
 
 //</listing>
-      const std::vector<ptrdiff_t> strvec; // see alt. ctor below
 
       // ctors
       arrinfo_t()

--- a/include/libcloudph++/lgrngn/opts_init.hpp
+++ b/include/libcloudph++/lgrngn/opts_init.hpp
@@ -56,6 +56,9 @@ namespace libcloudphxx
       // RH threshold for calculating equilibrium condition at t=0
       real_t RH_max;
 
+      // rng seed
+      int rng_seed;
+
       // ctor with defaults (C++03 compliant) ...
       opts_init_t() : 
         nx(0), ny(0), nz(0), // the defaults are OK for a parcel set-up 
@@ -67,7 +70,8 @@ namespace libcloudphxx
         sstp_cond(1), sstp_coal(1), sstp_chem(1),         
         chem_switch(false),  // chemical reactions turned off by default
         RH_max(.95), // value seggested in Lebo and Seinfeld 2011
-        chem_rho(0) // dry particle density  //TODO add checking if the user gave a different value (np w init)  (was 1.8e-3)
+        chem_rho(0), // dry particle density  //TODO add checking if the user gave a different value (np w init)  (was 1.8e-3)
+        rng_seed(44)
       {}
     };
   }

--- a/src/detail/urand.hpp
+++ b/src/detail/urand.hpp
@@ -4,6 +4,7 @@
 
 #if defined(__NVCC__)
 #  include <curand.h>
+#  include <limits>
 #else
 #  include <random>
 #  include <algorithm>
@@ -16,39 +17,56 @@ namespace libcloudphxx
     namespace detail
     {
       template <typename real_t, int backend>
-      class u01
+      class rng
       {
 #if !defined(__NVCC__)
 	// serial version using C++11's <random>
 	using engine_t = std::mt19937;
-        using dist_t = std::uniform_real_distribution<real_t>;
+        using dist_u01_t = std::uniform_real_distribution<real_t>;
+        using dist_un_t = std::uniform_int_distribution<unsigned int>;
 	engine_t engine;
-	dist_t dist;
+	dist_u01_t dist_u01;
+	dist_un_t dist_un;
 
-	struct fnctr
+	struct fnctr_u01
 	{
           engine_t &engine;
-          dist_t &dist;
-	  real_t operator()() { return dist(engine); }
+          dist_u01_t &dist_u01;
+	  real_t operator()() { return dist_u01(engine); }
+	};
+
+	struct fnctr_un
+	{
+          engine_t &engine;
+          dist_un_t &dist_un;
+	  real_t operator()() { return dist_un(engine); }
 	};
 
 	public:
 
         // ctor
-        u01() : engine(44), dist(0,1) {}
+        rng() : engine(44), dist_u01(0,1), dist_un(0, std::numeric_limits<unsigned int>::max()) {}
 
 	void generate_n(
 	  thrust_device::vector<real_t> &u01, 
 	  const thrust_size_t n
 	) {
           // note: generate_n copies the third argument!!!
-	  std::generate_n(u01.begin(), n, fnctr({.engine = engine, .dist = dist})); 
+	  std::generate_n(u01.begin(), n, fnctr_u01({.engine = engine, .dist_u01 = dist_u01})); 
+	}
+
+	void generate_n(
+	  thrust_device::vector<unsigned int> &un, 
+	  const thrust_size_t n
+	) {
+          // note: generate_n copies the third argument!!!
+	  std::generate_n(un.begin(), n, fnctr_un({.engine = engine, .dist_un = dist_un})); 
 	}
 #endif
       };
  
       template <typename real_t>
-      class u01<real_t, CUDA>
+      class rng<real_t, CUDA>
       {
 #if defined(__NVCC__)
 	// CUDA parallel version using curand
@@ -58,7 +76,7 @@ namespace libcloudphxx
 	
 	public:
 
-	u01()
+	rng()
 	{
           {
 	    int status = curandCreateGenerator(&gen, CURAND_RNG_PSEUDO_MTGP32);
@@ -72,7 +90,7 @@ namespace libcloudphxx
 	  }
         }
 
-	~u01()
+	~rng()
 	{
 	  int status = curandDestroyGenerator(gen); 
 	  assert(status == CURAND_STATUS_SUCCESS /* && "curandDestroyGenerator failed"*/);
@@ -95,6 +113,16 @@ namespace libcloudphxx
 	)
 	{
 	  int status = curandGenerateUniformDouble(gen, thrust::raw_pointer_cast(v.data()), n);
+	  assert(status == CURAND_STATUS_SUCCESS /* && "curandGenerateUniform failed"*/);
+          _unused(status);
+	}
+
+	void generate_n(
+	  thrust_device::vector<unsigned int> &v, 
+	  const thrust_size_t n
+	)
+	{
+	  int status = curandGenerate(gen, thrust::raw_pointer_cast(v.data()), n);
 	  assert(status == CURAND_STATUS_SUCCESS /* && "curandGenerateUniform failed"*/);
           _unused(status);
 	}

--- a/src/detail/urand.hpp
+++ b/src/detail/urand.hpp
@@ -45,7 +45,7 @@ namespace libcloudphxx
 	public:
 
         // ctor
-        rng() : engine(44), dist_u01(0,1), dist_un(0, std::numeric_limits<unsigned int>::max()) {}
+        rng(int seed) : engine(seed), dist_u01(0,1), dist_un(0, std::numeric_limits<unsigned int>::max()) {}
 
 	void generate_n(
 	  thrust_device::vector<real_t> &u01, 
@@ -76,7 +76,7 @@ namespace libcloudphxx
 	
 	public:
 
-	rng()
+	rng(int seed)
 	{
           {
 	    int status = curandCreateGenerator(&gen, CURAND_RNG_PSEUDO_MTGP32);
@@ -84,7 +84,7 @@ namespace libcloudphxx
 	    _unused(status);
           }
           {
-	    int status = curandSetPseudoRandomGeneratorSeed(gen, 44);
+	    int status = curandSetPseudoRandomGeneratorSeed(gen, seed);
 	    assert(status == CURAND_STATUS_SUCCESS /* && "curandSetPseudoRandomGeneratorSeed failed"*/);
             _unused(status);
 	  }

--- a/src/particles_impl_hskpng_sort.ipp
+++ b/src/particles_impl_hskpng_sort.ipp
@@ -28,11 +28,11 @@ namespace libcloudphxx
       else
       {
         // generating a random sorting key
-        rand_u01(n_part);
+        rand_un(n_part);
 
         // sorting the sequence with the random key
         thrust::sort_by_key(
-          u01.begin(), u01.end(),
+          un.begin(), un.end(),
           sorted_id.begin()
         );
 

--- a/src/particles_pimpl_ctor.ipp
+++ b/src/particles_pimpl_ctor.ipp
@@ -40,7 +40,7 @@ namespace libcloudphxx
       const int n_dims;
       const int n_cell; 
       const thrust_size_t n_part; 
-      detail::u01<real_t, device> rng;
+      detail::rng<real_t, device> rng;
 
       // pointer to collision kernel
       kernel_base<real_t, n_t> *p_kernel;
@@ -149,7 +149,10 @@ namespace libcloudphxx
       thrust_device::vector<real_t>
         tmp_device_real_part,
         tmp_device_real_cell,
-	&u01; // uniform random numbers between 0 and 1 // TODO: use the tmp array as rand argument?
+	&u01;  // uniform random numbers between 0 and 1 // TODO: use the tmp array as rand argument?
+      thrust_device::vector<unsigned int>
+        tmp_device_n_part,
+        &un; // uniform natural random numbers between 0 and max value of unsigned int
       thrust_device::vector<thrust_size_t>
         tmp_device_size_cell;
 
@@ -158,6 +161,9 @@ namespace libcloudphxx
 
       // fills u01[0:n] with random numbers
       void rand_u01(thrust_size_t n) { rng.generate_n(u01, n); }
+
+      // fills un[0:n] with random numbers
+      void rand_un(thrust_size_t n) { rng.generate_n(un, n); }
 
       // compile-time min(1, n) 
       int m1(int n) { return n == 0 ? 1 : n; }
@@ -186,6 +192,7 @@ namespace libcloudphxx
         zero(0), 
         sorted(false), 
         u01(tmp_device_real_part),
+        un(tmp_device_n_part),
         n_kernel_params(opts_init.kernel_parameters.size())
       {
         // sanity checks
@@ -214,6 +221,7 @@ namespace libcloudphxx
 	tmp_device_real_part.resize(n_part);
         tmp_device_real_cell.resize(n_cell);
         tmp_device_size_cell.resize(n_cell);
+	tmp_device_n_part.resize(n_part);
 
         // initialising host temporary arrays
         {

--- a/src/particles_pimpl_ctor.ipp
+++ b/src/particles_pimpl_ctor.ipp
@@ -193,7 +193,8 @@ namespace libcloudphxx
         sorted(false), 
         u01(tmp_device_real_part),
         un(tmp_device_n_part),
-        n_kernel_params(opts_init.kernel_parameters.size())
+        n_kernel_params(opts_init.kernel_parameters.size()),
+        rng(opts_init.rng_seed)
       {
         // sanity checks
         if (n_dims > 0)

--- a/tests/python/unit/api_lgrngn.py
+++ b/tests/python/unit/api_lgrngn.py
@@ -21,6 +21,7 @@ opts_init.dry_distros = {kappa:lognormal}
 opts_init.kernel = lgrngn.kernel_t.geometric
 opts_init.dt = 1
 opts_init.sd_conc_mean = 64
+opts_init.rng_seed = 396
 
 print "nx =", opts_init.nx
 print "ny =", opts_init.ny


### PR DESCRIPTION
ca. 10% speedup on CUDA for 10^6 SDs;
includes rng seed selection
