### PR TITLE
increase max it number in toms

### DIFF
--- a/include/libcloudph++/common/detail/toms748.hpp
+++ b/include/libcloudph++/common/detail/toms748.hpp
@@ -455,7 +455,7 @@ template <class F, class T>
 BOOST_GPU_ENABLED
 T toms748_solve(F f, const T& ax, const T& bx, const T& fax, const T& fbx)
 {
-  const uintmax_t n_iter = 20;
+  const uintmax_t n_iter = 44;
   uintmax_t max_iter = n_iter;
   T root = toms748_solve(f, ax, bx, fax, fbx, 
     common::detail::eps_tolerance<T>(sizeof(T) * 8 / 4),


### PR DESCRIPTION
Tested in icicle - improves results a bit, although a short timestep (1/15 s) is still needed.
