### PR TITLE
Cleanup after rename

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -42,15 +42,11 @@ it may contain useful information on obtaining the dependencies.
 
 1. To check the dependencies and compile the library, please try:
 
-  $ mkdir build
-
-  $ cd build
-
-  $ cmake ..
-
-  $ make
-
-  $ cd ..
+    $ mkdir build
+    $ cd build
+    $ cmake ..
+    $ make
+    $ cd ..
   
 The next two steps are optional test. Running the tests is highly
 recommended to verify if the library works correctly in your 
@@ -59,38 +55,29 @@ and install the library right away.
   
 2. To perform unit and some other quick tests, please try:
 
-  $ cd build/tests
-
-  $ make test
-
-  $ cd ../..
+    $ cd build/tests
+    $ make test
+    $ cd ../..
 
 These tests should complete in a few minutes.
 
 3. To reproduce all results from the GMD paper, please try:
 
-  $ cd models/kinematic_2D
-
-  $ mkdir build 
-
-  $ cd build
-
-  $ cmake ..
-
-  $ make
-
-  $ make test     
-
-  $ cd ../../..
+    $ cd models/kinematic_2D
+    $ mkdir build 
+    $ cd build
+    $ cmake ..
+    $ make
+    $ make test     
+    $ cd ../../..
 
 This can take over an hour if a GPU is available or longer if using
 CPU only. 
 
 4. To install the library system-wide, please try:
 
-  $ cd build
-
-  $ sudo make install
+    $ cd build
+    $ sudo make install
 
 This will copy the libcloudph++ headers into the system include path
 (e.g. /usr/include/libcloudph++), copy the libcloudph++-config.cmake 

--- a/Readme.md
+++ b/Readme.md
@@ -41,10 +41,15 @@ shipped with libcloudph++ on fresh Ubuntu and OSX installations -
 it may contain useful information on obtaining the dependencies.
 
 1. To check the dependencies and compile the library, please try:
+
   $ mkdir build
+
   $ cd build
+
   $ cmake ..
+
   $ make
+
   $ cd ..
   
 The next two steps are optional test. Running the tests is highly
@@ -53,26 +58,38 @@ environment. Nevertheless, in principle you can skip to step four
 and install the library right away.
   
 2. To perform unit and some other quick tests, please try:
+
   $ cd build/tests
+
   $ make test
+
   $ cd ../..
 
 These tests should complete in a few minutes.
 
 3. To reproduce all results from the GMD paper, please try:
-  $ cd tests/paper_2015_GMD
+
+  $ cd models/kinematic_2D
+
   $ mkdir build 
+
   $ cd build
+
   $ cmake ..
+
   $ make
+
   $ make test     
+
   $ cd ../../..
 
 This can take over an hour if a GPU is available or longer if using
 CPU only. 
 
 4. To install the library system-wide, please try:
+
   $ cd build
+
   $ sudo make install
 
 This will copy the libcloudph++ headers into the system include path

--- a/Readme.md
+++ b/Readme.md
@@ -42,12 +42,14 @@ it may contain useful information on obtaining the dependencies.
 
 1. To check the dependencies and compile the library, please try:
 
+```bash
     $ mkdir build
     $ cd build
     $ cmake ..
     $ make
     $ cd ..
-  
+```
+
 The next two steps are optional test. Running the tests is highly
 recommended to verify if the library works correctly in your 
 environment. Nevertheless, in principle you can skip to step four

--- a/Readme.md
+++ b/Readme.md
@@ -57,14 +57,17 @@ and install the library right away.
   
 2. To perform unit and some other quick tests, please try:
 
+```bash
     $ cd build/tests
     $ make test
     $ cd ../..
+```
 
 These tests should complete in a few minutes.
 
 3. To reproduce all results from the GMD paper, please try:
 
+```bash
     $ cd models/kinematic_2D
     $ mkdir build 
     $ cd build
@@ -72,14 +75,17 @@ These tests should complete in a few minutes.
     $ make
     $ make test     
     $ cd ../../..
+```
 
 This can take over an hour if a GPU is available or longer if using
 CPU only. 
 
 4. To install the library system-wide, please try:
 
+```bash
     $ cd build
     $ sudo make install
+```
 
 This will copy the libcloudph++ headers into the system include path
 (e.g. /usr/include/libcloudph++), copy the libcloudph++-config.cmake 

--- a/models/kinematic_2D/src/CMakeLists.txt
+++ b/models/kinematic_2D/src/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
   # make the Release flags the default
   set(CMAKE_CXX_FLAGS ${libmpdataxx_CXX_FLAGS_RELEASE})
@@ -19,7 +18,9 @@ add_executable(icicle icicle.cpp)
 
 target_link_libraries(icicle ${libmpdataxx_LIBRARIES})
 target_include_directories(icicle PUBLIC ${libmpdataxx_INCLUDE_DIRS})
+
 target_link_libraries(icicle ${libcloudphxx_LIBRARIES})
+
 find_package(Boost COMPONENTS program_options REQUIRED)
 target_link_libraries(icicle ${Boost_LIBRARIES})
 

--- a/models/kinematic_2D/tests/paper_GMD_2015/fig_a/gnuplot.hpp
+++ b/models/kinematic_2D/tests/paper_GMD_2015/fig_a/gnuplot.hpp
@@ -15,7 +15,7 @@ void init(
     boost::filesystem::path(file).parent_path()
   );
 
-  gp << "set term svg dynamic enhanced fsize 13 size " << nx * 500 << "," << ny * 500 << "\n";
+  gp << "set term svg size " << nx * 500 << "," << ny * 500 << "\n";
   gp << "set size square\n";
   gp << "set encoding utf8\n";
   // progressive-rock connoisseur palette ;)

--- a/models/kinematic_2D/tests/paper_GMD_2015/fig_a/hdf5.hpp
+++ b/models/kinematic_2D/tests/paper_GMD_2015/fig_a/hdf5.hpp
@@ -17,10 +17,11 @@ std::map<std::string, int> h5n(
 
   {
     auto h5d = h5f.openDataSet("T");
+    auto h5g = h5f.openGroup("advection");
 
     float dt;
     {
-      auto attr = h5d.openAttribute("dt");
+      auto attr = h5g.openAttribute("dt");
       attr.read(attr.getDataType(), &dt);
     }
 

--- a/models/kinematic_2D/tests/thesis_AJ_2017/thesis_chap_6/hdf5.hpp
+++ b/models/kinematic_2D/tests/thesis_AJ_2017/thesis_chap_6/hdf5.hpp
@@ -17,10 +17,11 @@ std::map<std::string, int> h5n(
 
   {
     auto h5d = h5f.openDataSet("T");
+    auto h5g = h5f.openGroup("advection");
 
     float dt;
     {
-      auto attr = h5d.openAttribute("dt");
+      auto attr = h5g.openAttribute("dt");
       attr.read(attr.getDataType(), &dt);
     }
 


### PR DESCRIPTION
- updating Readme by renaming tests/paper_2015_GMD to models/kinematic_2D
- adding fancy code formating in Readme
- remove "dynamic enhanced fsize 13" from gnuplot script (not necessary and doesn't work for everybody)
- updating reading routines from hdf5 files to the new dt storage place for GMD_paper and thesis