### PR TITLE
Blk 2m limiter

### DIFF
--- a/include/libcloudph++/blk_2m/common_formulae.hpp
+++ b/include/libcloudph++/blk_2m/common_formulae.hpp
@@ -17,6 +17,16 @@ namespace libcloudphxx
     {
       using namespace common::moist_air;
 
+      // numerical epsilon
+      template<typename real_t>
+      real_t num_eps = std::numeric_limits<real_t>::epsilon();
+      // typical scale * numerical precission to get the limit
+      // below whitch microphysics variables should be treated as zero
+      libcloudphxx_const(si::dimensionless, rc_eps, 1e-3 * num_eps<real_t>, 1)
+      libcloudphxx_const(si::dimensionless, rr_eps, 1e-4 * num_eps<real_t>, 1)
+      libcloudphxx_const(si::dimensionless, nc_eps, 1e7  * num_eps<real_t>, 1) // #/kg
+      libcloudphxx_const(si::dimensionless, nr_eps, 1e6  * num_eps<real_t>, 1) // #/kg
+
       // eq.2 Morrison and Grabowski 2007
       template<typename real_t>
       inline quantity<si::dimensionless, real_t> eta(

--- a/include/libcloudph++/blk_2m/rhs_cellwise.hpp
+++ b/include/libcloudph++/blk_2m/rhs_cellwise.hpp
@@ -48,19 +48,6 @@ namespace libcloudphxx
       using namespace common::moist_air;
       using namespace common::theta_dry;
 
-      // TODO - do we want it to be runtime params?
-      // typical assumed scales of cloud/rain water mixing ratios and concentrations
-      using inverse_mass = divide_typeof_helper<si::dimensionless, si::mass>::type;
-      const quantity<inverse_mass,      real_t> nc_scale = real_t(1e7) * si::dimensionless() / si::kilograms;
-      const quantity<inverse_mass,      real_t> nr_scale = real_t(1e6) * si::dimensionless() / si::kilograms;
-      const quantity<si::dimensionless, real_t> rc_scale = real_t(1e-3) * si::dimensionless();
-      const quantity<si::dimensionless, real_t> rr_scale = real_t(1e-4) * si::dimensionless();
-      // multiply by the numerical precission to get the limit below whitch it should be treated as zero
-      const quantity<si::dimensionless, real_t> nc_eps = nc_scale * si::kilograms * std::numeric_limits<real_t>::epsilon();
-      const quantity<si::dimensionless, real_t> nr_eps = nr_scale * si::kilograms * std::numeric_limits<real_t>::epsilon();
-      const quantity<si::dimensionless, real_t> rc_eps = rc_scale * std::numeric_limits<real_t>::epsilon();
-      const quantity<si::dimensionless, real_t> rr_eps = rr_scale * std::numeric_limits<real_t>::epsilon();
-
       for (auto tup : zip(
         dot_th_cont,
         dot_rv_cont,
@@ -146,7 +133,7 @@ namespace libcloudphxx
         if (opts.cond)
         {
           // condensation/evaporation of cloud water (see Morrison & Grabowski 2007)
-          if (rc > rc_eps && nc > nc_eps)
+          if (rc > rc_eps<real_t>() && nc > nc_eps<real_t>())
           {      //  ^^   TODO is it possible?
             quantity<si::frequency, real_t> tmp =
               cond_evap_rate<real_t>(
@@ -159,7 +146,7 @@ namespace libcloudphxx
           }
 
           // evaporation of rain (see Morrison & Grabowski 2007)
-          if (rr > rr_eps && nr > nr_eps)
+          if (rr > rr_eps<real_t>() && nr > nr_eps<real_t>())
           {
             quantity<si::frequency, real_t> tmp =
               std::min(
@@ -210,7 +197,7 @@ namespace libcloudphxx
           // autoconversion rate (as in Khairoutdinov and Kogan 2000, but see Wood 2005 table 1)
           if (opts.acnv)
           {
-            if (rc > rc_eps && nc > nc_eps)
+            if (rc > rc_eps<real_t>() && nc > nc_eps<real_t>())
             {
               quantity<si::frequency, real_t> tmp = autoconv_rate(rc, nc, rhod,
                                                                   opts.acnv_A * si::dimensionless(),
@@ -239,7 +226,7 @@ namespace libcloudphxx
           // accretion rate (as in Khairoutdinov and Kogan 2000, but see Wood 2005 table 1)
           if (opts.accr && !cloud_limiter && !rain_limiter)
           {
-            if (rc > rc_eps && nc > nc_eps && rr > rr_eps)
+            if (rc > rc_eps<real_t>() && nc > nc_eps<real_t>() && rr > rr_eps<real_t>())
             {
               quantity<si::frequency, real_t> tmp = accretion_rate(rc, rr_dim);
 
@@ -268,7 +255,7 @@ namespace libcloudphxx
             if(cloud_limiter)
               local_dot_nc = - nc / dt;
             // else calc sink of nc from local_dot_rr
-            else if (nc > nc_eps && local_dot_rr > rr_eps)
+            else if (nc > nc_eps<real_t>() && local_dot_rr > rr_eps<real_t>())
             {
               quantity<divide_typeof_helper<si::frequency, si::mass>::type, real_t> tmp =
                 collision_sink_rate(local_dot_rr / si::seconds, r_drop_c(rc, nc, rhod));

--- a/include/libcloudph++/blk_2m/rhs_cellwise.hpp
+++ b/include/libcloudph++/blk_2m/rhs_cellwise.hpp
@@ -48,6 +48,19 @@ namespace libcloudphxx
       using namespace common::moist_air;
       using namespace common::theta_dry;
 
+      // TODO - do we want it to be runtime params?
+      // typical assumed scales of cloud/rain water mixing ratios and concentrations
+      using inverse_mass = divide_typeof_helper<si::dimensionless, si::mass>::type;
+      const quantity<inverse_mass,      real_t> nc_scale = real_t(1e7) * si::dimensionless() / si::kilograms;
+      const quantity<inverse_mass,      real_t> nr_scale = real_t(1e6) * si::dimensionless() / si::kilograms;
+      const quantity<si::dimensionless, real_t> rc_scale = real_t(1e-3) * si::dimensionless();
+      const quantity<si::dimensionless, real_t> rr_scale = real_t(1e-4) * si::dimensionless();
+      // multiply by the numerical precission to get the limit below whitch it should be treated as zero
+      const quantity<si::dimensionless, real_t> nc_eps = nc_scale * si::kilograms * std::numeric_limits<real_t>::epsilon();
+      const quantity<si::dimensionless, real_t> nr_eps = nr_scale * si::kilograms * std::numeric_limits<real_t>::epsilon();
+      const quantity<si::dimensionless, real_t> rc_eps = rc_scale * std::numeric_limits<real_t>::epsilon();
+      const quantity<si::dimensionless, real_t> rr_eps = rr_scale * std::numeric_limits<real_t>::epsilon();
+
       for (auto tup : zip(
         dot_th_cont,
         dot_rv_cont,
@@ -133,7 +146,7 @@ namespace libcloudphxx
         if (opts.cond)
         {
           // condensation/evaporation of cloud water (see Morrison & Grabowski 2007)
-          if (rc > 0 && nc > 0)
+          if (rc > rc_eps && nc > nc_eps)
           {      //  ^^   TODO is it possible?
             quantity<si::frequency, real_t> tmp =
               cond_evap_rate<real_t>(
@@ -146,7 +159,7 @@ namespace libcloudphxx
           }
 
           // evaporation of rain (see Morrison & Grabowski 2007)
-          if (rr > 0 && nr > 0)
+          if (rr > rr_eps && nr > nr_eps)
           {
             quantity<si::frequency, real_t> tmp =
               std::min(
@@ -197,7 +210,7 @@ namespace libcloudphxx
           // autoconversion rate (as in Khairoutdinov and Kogan 2000, but see Wood 2005 table 1)
           if (opts.acnv)
           {
-            if (rc > 0 && nc > 0)
+            if (rc > rc_eps && nc > nc_eps)
             {
               quantity<si::frequency, real_t> tmp = autoconv_rate(rc, nc, rhod,
                                                                   opts.acnv_A * si::dimensionless(),
@@ -207,6 +220,7 @@ namespace libcloudphxx
 
               // so that autoconversion doesn't take more rc than there is
               tmp = std::min(tmp, rc / (dt * si::seconds));
+
               assert(tmp * si::seconds >= 0 && "autoconv rate has to be >= 0");
 
               local_dot_rc -= tmp * si::seconds;
@@ -225,7 +239,7 @@ namespace libcloudphxx
           // accretion rate (as in Khairoutdinov and Kogan 2000, but see Wood 2005 table 1)
           if (opts.accr && !cloud_limiter && !rain_limiter)
           {
-            if (rc > 0 && nc > 0 && rr > 0)
+            if (rc > rc_eps && nc > nc_eps && rr > rr_eps)
             {
               quantity<si::frequency, real_t> tmp = accretion_rate(rc, rr_dim);
 
@@ -254,7 +268,7 @@ namespace libcloudphxx
             if(cloud_limiter)
               local_dot_nc = - nc / dt;
             // else calc sink of nc from local_dot_rr
-            else if (nc > 0 && local_dot_rr > 0)
+            else if (nc > nc_eps && local_dot_rr > rr_eps)
             {
               quantity<divide_typeof_helper<si::frequency, si::mass>::type, real_t> tmp =
                 collision_sink_rate(local_dot_rr / si::seconds, r_drop_c(rc, nc, rhod));

--- a/include/libcloudph++/blk_2m/terminal_vel_formulae.hpp
+++ b/include/libcloudph++/blk_2m/terminal_vel_formulae.hpp
@@ -16,13 +16,13 @@ namespace libcloudphxx
   namespace blk_2m
   {
     namespace formulae
-    { 
-      // terminal fall velocity based on the data from Gunn and Kinzer (1949) and Beard (1976) 
+    {
+      // terminal fall velocity based on the data from Gunn and Kinzer (1949) and Beard (1976)
       // modified by Simmel et al. (2002) -> see table 2 there
 
       // the actuall fall velocity for rain density or concentration is calculated as mass or number weighted mean:
       // v_m = \int N(D) m(D) vt(D) dD
-      // v_n = \int N(D)      vt(D) dD 
+      // v_n = \int N(D)      vt(D) dD
 
       libcloudphxx_const(si::length, d1,  134.43 * 1e-6, si::metres)
       libcloudphxx_const(si::length, d2, 1511.64 * 1e-6, si::metres)
@@ -33,12 +33,12 @@ namespace libcloudphxx
         const quantity<si::length, real_t> &drop_r
       ) {
          assert(drop_r >= 0 * si::metres  && "mean drop radius cannot be < 0");
-         
+
          if (real_t(2) * drop_r == 0 * si::metres)   {return 0;} //TODO if no rain, terminal velocity = 0
-         else if (real_t(2) * drop_r < d1<real_t>()) {return 4.5795 * 1e5;} 
-         else if (real_t(2) * drop_r < d2<real_t>()) {return 4.962  * 1e3;} 
-         else if (real_t(2) * drop_r < d3<real_t>()) {return 1.732  * 1e3;} 
-         else                                        {return 9.17   * 1e2;} 
+         else if (real_t(2) * drop_r < d1<real_t>()) {return 4.5795 * 1e5;}
+         else if (real_t(2) * drop_r < d2<real_t>()) {return 4.962  * 1e3;}
+         else if (real_t(2) * drop_r < d3<real_t>()) {return 1.732  * 1e3;}
+         else                                        {return 9.17   * 1e2;}
       }
 
       template <typename real_t>
@@ -47,10 +47,10 @@ namespace libcloudphxx
       ) {
          assert(drop_r >= 0 * si::metres  && "mean drop radius cannot be < 0");
 
-         if (real_t(2) * drop_r < d1<real_t>())      {return 2./3;} 
-         else if (real_t(2) * drop_r < d2<real_t>()) {return 1./3;} 
-         else if (real_t(2) * drop_r < d3<real_t>()) {return 1./6;} 
-         else                                        {return 0;} 
+         if (real_t(2) * drop_r < d1<real_t>())      {return 2./3;}
+         else if (real_t(2) * drop_r < d2<real_t>()) {return 1./3;}
+         else if (real_t(2) * drop_r < d3<real_t>()) {return 1./6;}
+         else                                        {return 0;}
       }
 
       //helper intergrals for vm
@@ -60,7 +60,7 @@ namespace libcloudphxx
           const quantity<divide_typeof_helper<si::dimensionless, si::length>::type, real_t> &lbd, //slope of assumed exponential size distribution
           const quantity<si::length, real_t> &D // diameter
         ) {
-          auto tmp =  - pow(lbd * si::metres, -6) * exp(-lbd * D) * 
+          auto tmp =  - pow(lbd * si::metres, -6) * exp(-lbd * D) *
             (pow(real_t(lbd * D), 5) + 5 * pow(real_t(lbd * D), 4) * 20 * pow(real_t(lbd * D), 3) + 60 * pow(real_t(lbd * D), 2) + 120 * real_t(lbd * D) + 120);
 
           assert(finite(tmp) && "mint_1 is finite failed");
@@ -72,7 +72,7 @@ namespace libcloudphxx
           const quantity<divide_typeof_helper<si::dimensionless, si::length>::type, real_t> &lbd, //slope of assumed exponential size distribution
           const quantity<si::length, real_t> &D // diameter
         ) {
-          auto tmp = - pow(real_t(lbd * si::metres), -5) * exp(-lbd * D) * 
+          auto tmp = - pow(real_t(lbd * si::metres), -5) * exp(-lbd * D) *
             (pow(real_t(lbd * D), 4) + 4 * pow(real_t(lbd * D), 3) * 12 * pow(real_t(lbd * D), 2) + 24 * real_t(lbd * D) + 24);
 
           assert(finite(tmp) && "mint_2 is finite failed");
@@ -84,8 +84,8 @@ namespace libcloudphxx
           const quantity<divide_typeof_helper<si::dimensionless, si::length>::type, real_t> &lbd, // slope of assumed exponential size distribution
           const quantity<si::length, real_t> &D // diameter
         ) {
-          auto tmp = real_t(1./16) / pow(real_t(lbd * si::metres), real_t(9./2)) 
-                   * (105 * sqrt(pi<real_t>()) * std::erf(sqrt(lbd * D)) 
+          auto tmp = real_t(1./16) / pow(real_t(lbd * si::metres), real_t(9./2))
+                   * (105 * sqrt(pi<real_t>()) * std::erf(sqrt(lbd * D))
                       - 2 * sqrt(lbd * D) * exp(-lbd * D) * (8 * pow(real_t(lbd * D), 3) + 28 * pow(real_t(lbd * D), 2) + 70 * real_t(lbd * D) + 105)
                    );
 
@@ -99,7 +99,7 @@ namespace libcloudphxx
           const quantity<divide_typeof_helper<si::dimensionless, si::length>::type, real_t> &lbd, //slope of assumed exponential size distribution
           const quantity<si::length, real_t> &D // diameter
         ) {
-          auto tmp = - pow(real_t(lbd * si::metres), -1) * exp(-lbd * D); 
+          auto tmp = - pow(real_t(lbd * si::metres), -1) * exp(-lbd * D);
 
           assert(finite(tmp) && "int_4 is finite failed");
           return tmp;
@@ -148,31 +148,31 @@ namespace libcloudphxx
         const quantity<si::mass_density, real_t> &rhod,
         const quantity<si::dimensionless, real_t> &rr,
         const quantity<divide_typeof_helper<si::dimensionless, si::mass>::type, real_t> &nr
-      ) { 
-        if (rr == 0 || nr == 0 / si::kilograms) 
+      ) {
+        if (rr < rr_eps<real_t>() || nr < nr_eps<real_t>() / si::kilograms)
           return 0 * si::metres_per_second;
 
         quantity<divide_typeof_helper<si::dimensionless, si::length>::type, real_t> lbd = lambda_r(nr, rr);
 
-        // eq. A4 in Morrison 2005 
-        auto tmp = rho_stp<real_t>() / rhod 
-          * lbd * si::metres * c_md<real_t>() 
-          * si::cubic_metres / si::kilograms // to make it dimensionless 
+        // eq. A4 in Morrison 2005
+        auto tmp = rho_stp<real_t>() / rhod
+          * lbd * si::metres * c_md<real_t>()
+          * si::cubic_metres / si::kilograms // to make it dimensionless
           * real_t(1000) // mass of the drop in grams
           * (
-	    alpha_fall(d1<real_t>() / real_t(2)) 
-            * pow(c_md<real_t>() * si::cubic_metres / si::kilograms * real_t(1000), beta_fall(d1<real_t>() / real_t(2))) 
+	    alpha_fall(d1<real_t>() / real_t(2))
+            * pow(c_md<real_t>() * si::cubic_metres / si::kilograms * real_t(1000), beta_fall(d1<real_t>() / real_t(2)))
 	    * (mint_1(lbd, d1<real_t>()) - mint_1(lbd, real_t(0) * si::metres))
 	    +
-	    alpha_fall(d1<real_t>() + d2<real_t>() / real_t(2)) 
-            * pow(c_md<real_t>() * si::cubic_metres / si::kilograms * real_t(1000), beta_fall(d1<real_t>() + d2<real_t>() / real_t(2))) 
+	    alpha_fall(d1<real_t>() + d2<real_t>() / real_t(2))
+            * pow(c_md<real_t>() * si::cubic_metres / si::kilograms * real_t(1000), beta_fall(d1<real_t>() + d2<real_t>() / real_t(2)))
 	    * (mint_2(lbd, d2<real_t>()) - mint_2(lbd, d1<real_t>()))
 	    +
-	    alpha_fall(d2<real_t>() + d3<real_t>() / real_t(2)) 
-            * pow(c_md<real_t>() * si::cubic_metres / si::kilograms * real_t(1000), beta_fall(d2<real_t>() + d3<real_t>() / real_t(2))) 
+	    alpha_fall(d2<real_t>() + d3<real_t>() / real_t(2))
+            * pow(c_md<real_t>() * si::cubic_metres / si::kilograms * real_t(1000), beta_fall(d2<real_t>() + d3<real_t>() / real_t(2)))
 	    * (mint_3(lbd, d3<real_t>()) - mint_3(lbd, d2<real_t>()))
 	    +
-	    alpha_fall(real_t(2) * d3<real_t>()) 
+	    alpha_fall(real_t(2) * d3<real_t>())
             * (real_t(0) - int_4(lbd, d3<real_t>()))
 	  ) * real_t(1e-2) * si::metres/si::seconds;  // velocity in metres/seconds
 
@@ -187,29 +187,29 @@ namespace libcloudphxx
         const quantity<si::mass_density, real_t> &rhod,
         const quantity<si::dimensionless, real_t> &rr,
         const quantity<divide_typeof_helper<si::dimensionless, si::mass>::type, real_t> &nr
-      ) { 
-        if (rr == 0 || nr == 0 / si::kilograms) 
+      ) {
+        if (rr < rr_eps<real_t>() || nr < nr_eps<real_t>() / si::kilograms)
           return 0 * si::metres_per_second;
 
         quantity<divide_typeof_helper<si::dimensionless, si::length>::type, real_t> lbd = lambda_r(nr, rr);
 
         // eq A4 in Morrison 2005
-        auto tmp = rho_stp<real_t>() / rhod 
+        auto tmp = rho_stp<real_t>() / rhod
           * (
-	   alpha_fall(d1<real_t>() / real_t(2)) 
-           * pow(c_md<real_t>() * si::cubic_metres / si::kilograms * real_t(1000), beta_fall(d1<real_t>() / real_t(2))) 
+	   alpha_fall(d1<real_t>() / real_t(2))
+           * pow(c_md<real_t>() * si::cubic_metres / si::kilograms * real_t(1000), beta_fall(d1<real_t>() / real_t(2)))
            * (nint_1(lbd, d1<real_t>()) - nint_1(lbd, real_t(0) * si::metres))
 	   +
-           alpha_fall(d1<real_t>() + d2<real_t>() / real_t(2)) 
-           * pow(c_md<real_t>() * si::cubic_metres / si::kilograms * real_t(1000), beta_fall(d1<real_t>() + d2<real_t>() / real_t(2))) 
+           alpha_fall(d1<real_t>() + d2<real_t>() / real_t(2))
+           * pow(c_md<real_t>() * si::cubic_metres / si::kilograms * real_t(1000), beta_fall(d1<real_t>() + d2<real_t>() / real_t(2)))
            * (nint_2(lbd, d2<real_t>()) - nint_2(lbd, d1<real_t>()))
            +
-           alpha_fall(d2<real_t>() + d3<real_t>() / real_t(2)) 
-           * pow(c_md<real_t>() * si::cubic_metres / si::kilograms * real_t(1000), beta_fall(d2<real_t>() + d3<real_t>() / real_t(2))) 
+           alpha_fall(d2<real_t>() + d3<real_t>() / real_t(2))
+           * pow(c_md<real_t>() * si::cubic_metres / si::kilograms * real_t(1000), beta_fall(d2<real_t>() + d3<real_t>() / real_t(2)))
            * (nint_3(lbd, d3<real_t>()) - nint_3(lbd, d2<real_t>()))
            +
            alpha_fall(real_t(2) * d3<real_t>()) * (real_t(0) - int_4(lbd, d3<real_t>()))
-          ) 
+          )
           * real_t(1e-2) * si::metres/si::seconds;  // velocity in metres/seconds
 
 //return std::max(real_t(0), real_t(tmp / si::metres_per_second)) * si::metres_per_second;


### PR DESCRIPTION
Turns out that using 0 as a limiting threshold is not good. For rc~1e-19 the autoconversion passes through the if rc>0 condition  and later creates negative rate (due to numeric reasons).

It helps to compare not with 0 but a "small number". Here the small number is created as a product of numerical epsilon that depends on the floating point format used in the simulation and the assumed typical scale of the limited variable. 